### PR TITLE
Use Buffers instead of Javascript Arrays

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -56,7 +56,8 @@ Filter.create = function create(elements, falsePositiveRate, nTweak, nFlags) {
   // See: https://github.com/bitcoin/bitcoin/blob/master/src/bloom.cpp
   var size = -1.0 / Filter.LN2SQUARED * elements * Math.log(falsePositiveRate);
   var filterSize = Math.floor(size / 8);
-  info.vData = Buffer.alloc(filterSize, 0);
+  info.vData = new Buffer(filterSize);
+  info.vData.fill(0);
 
   // The ideal number of hash functions is:
   // filter size * ln(2) / number of elements
@@ -109,7 +110,8 @@ Filter.prototype.contains = function contains(data) {
 };
 
 Filter.prototype.clear = function clear() {
-  this.vData = Buffer.alloc(this.vData.length, 0);
+  this.vData = new Buffer(this.vData.length);
+  this.vData.fill(0);
 };
 
 Filter.prototype.inspect = function inspect() {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -22,7 +22,7 @@ function Filter(arg) {
     if (!arg.vData) {
       throw new TypeError('Data object should include filter data "vData"');
     }
-    this.vData = new Uint8Array(arg.vData);
+    this.vData = new Buffer(arg.vData);
     if (!arg.nHashFuncs) {
       throw new TypeError('Data object should include number of hash functions "nHashFuncs"');
     }
@@ -56,7 +56,7 @@ Filter.create = function create(elements, falsePositiveRate, nTweak, nFlags) {
   // See: https://github.com/bitcoin/bitcoin/blob/master/src/bloom.cpp
   var size = -1.0 / Filter.LN2SQUARED * elements * Math.log(falsePositiveRate);
   var filterSize = Math.floor(size / 8);
-  info.vData = new Uint8Array(filterSize);
+  info.vData = Buffer.alloc(filterSize, 0);
 
   // The ideal number of hash functions is:
   // filter size * ln(2) / number of elements
@@ -109,12 +109,12 @@ Filter.prototype.contains = function contains(data) {
 };
 
 Filter.prototype.clear = function clear() {
-  this.vData = new Uint8Array(this.vData.length);
+  this.vData = Buffer.alloc(this.vData.length, 0);
 };
 
 Filter.prototype.inspect = function inspect() {
   return '<BloomFilter:' +
-    this.vData + ' nHashFuncs:' +
+    this.vData.toJSON().data + ' nHashFuncs:' +
     this.nHashFuncs + ' nTweak:' +
     this.nTweak + ' nFlags:' +
     this.nFlags + '>';

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -22,7 +22,7 @@ function Filter(arg) {
     if (!arg.vData) {
       throw new TypeError('Data object should include filter data "vData"');
     }
-    this.vData = arg.vData;
+    this.vData = new Uint8Array(arg.vData);
     if (!arg.nHashFuncs) {
       throw new TypeError('Data object should include number of hash functions "nHashFuncs"');
     }
@@ -56,10 +56,7 @@ Filter.create = function create(elements, falsePositiveRate, nTweak, nFlags) {
   // See: https://github.com/bitcoin/bitcoin/blob/master/src/bloom.cpp
   var size = -1.0 / Filter.LN2SQUARED * elements * Math.log(falsePositiveRate);
   var filterSize = Math.floor(size / 8);
-  info.vData = [];
-  for (var i = 0; i < filterSize; i++) {
-    info.vData.push(0);
-  }
+  info.vData = new Uint8Array(filterSize);
 
   // The ideal number of hash functions is:
   // filter size * ln(2) / number of elements
@@ -112,7 +109,7 @@ Filter.prototype.contains = function contains(data) {
 };
 
 Filter.prototype.clear = function clear() {
-  this.vData = [];
+  this.vData = new Uint8Array(this.vData.length);
 };
 
 Filter.prototype.inspect = function inspect() {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -22,9 +22,6 @@ function Filter(arg) {
     if (!arg.vData) {
       throw new TypeError('Data object should include filter data "vData"');
     }
-    if (arg.vData.length > Filter.MAX_BLOOM_FILTER_SIZE * 8) {
-      throw new TypeError('"vData" exceeded max size "' + Filter.MAX_BLOOM_FILTER_SIZE + '"');
-    }
     this.vData = arg.vData;
     if (!arg.nHashFuncs) {
       throw new TypeError('Data object should include number of hash functions "nHashFuncs"');
@@ -59,10 +56,6 @@ Filter.create = function create(elements, falsePositiveRate, nTweak, nFlags) {
   // See: https://github.com/bitcoin/bitcoin/blob/master/src/bloom.cpp
   var size = -1.0 / Filter.LN2SQUARED * elements * Math.log(falsePositiveRate);
   var filterSize = Math.floor(size / 8);
-  var max = Filter.MAX_BLOOM_FILTER_SIZE * 8;
-  if (filterSize > max) {
-    filterSize = max;
-  }
   info.vData = [];
   for (var i = 0; i < filterSize; i++) {
     info.vData.push(0);
@@ -133,7 +126,6 @@ Filter.prototype.inspect = function inspect() {
 Filter.BLOOM_UPDATE_NONE = 0;
 Filter.BLOOM_UPDATE_ALL = 1;
 Filter.BLOOM_UPDATE_P2PUBKEY_ONLY = 2;
-Filter.MAX_BLOOM_FILTER_SIZE = 36000; // bytes
 Filter.MAX_HASH_FUNCS = 50;
 Filter.MIN_HASH_FUNCS = 1;
 Filter.LN2SQUARED = Math.pow(Math.log(2), 2); // 0.4804530139182014246671025263266649717305529515945455

--- a/test/index.js
+++ b/test/index.js
@@ -140,7 +140,7 @@ describe('Bloom', function() {
       var actual = filter.toObject();
 
       var expected = {
-        vData: new Uint8Array([ 97, 78, 155 ]),
+        vData: new Buffer([ 97, 78, 155 ]),
         nHashFuncs: 5,
         nTweak: 0,
         nFlags: 1
@@ -167,7 +167,7 @@ describe('Bloom', function() {
       assert(filter.contains(ParseHex('b9300670b4c5366e95b2699e8b18bc75e5f729c5')));
 
       var expected = {
-        vData: new Uint8Array([ 206, 66, 153 ]),
+        vData: new Buffer([ 206, 66, 153 ]),
         nHashFuncs: 5,
         nTweak: 2147483649,
         nFlags: 1

--- a/test/index.js
+++ b/test/index.js
@@ -140,7 +140,7 @@ describe('Bloom', function() {
       var actual = filter.toObject();
 
       var expected = {
-        vData: [ 97, 78, 155 ],
+        vData: new Uint8Array([ 97, 78, 155 ]),
         nHashFuncs: 5,
         nTweak: 0,
         nFlags: 1
@@ -167,7 +167,7 @@ describe('Bloom', function() {
       assert(filter.contains(ParseHex('b9300670b4c5366e95b2699e8b18bc75e5f729c5')));
 
       var expected = {
-        vData: [ 206, 66, 153 ],
+        vData: new Uint8Array([ 206, 66, 153 ]),
         nHashFuncs: 5,
         nTweak: 2147483649,
         nFlags: 1
@@ -222,8 +222,7 @@ describe('Bloom', function() {
     });
 
     it('use the max size', function() {
-      var filter = Filter.create(900000000000000000000000000000000000, 0.01);
-      filter.vData.length.should.equal(Filter.MAX_BLOOM_FILTER_SIZE * 8);
+      var filter = Filter.create(100000000, 0.01);
     });
 
     it('use the max number of hash funcs', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -221,10 +221,6 @@ describe('Bloom', function() {
       assert(!filter.contains(a));
     });
 
-    it('use the max size', function() {
-      var filter = Filter.create(100000000, 0.01);
-    });
-
     it('use the max number of hash funcs', function() {
       var filter = Filter.create(10, 0.0000000000000001);
       filter.nHashFuncs.should.equal(Filter.MAX_HASH_FUNCS);

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ function ParseHex(str) {
     result.push(parseInt(str.substring(0, 2), 16));
     str = str.substring(2, str.length);
   }
-  var buf = new Buffer(result, 16);
+  var buf = new Buffer(result);
   return buf;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -71,12 +71,6 @@ describe('Bloom', function() {
       }).to.throw('Data object should include filter data "vData"');
     });
 
-    it('error if vData exceeds max', function(){
-      expect(function(){
-        var a = new Filter({vData: Array(10000000)});
-      }).to.throw('"vData" exceeded');
-    });
-
     it('error if missing nHashFuncs', function(){
       expect(function(){
         var a = new Filter({vData: [121, 12, 200]});


### PR DESCRIPTION
Any reason why the library uses Javascript arrays? Buffers are faster, store less information, and make it easier to write to IO streams (files, databases, etc). 

IMO this makes the library the best (and most versatile) Javascript bloom-filter library out there. I needed a big filter (so I removed the max size, seems ok with the Buffer speed and efficiency improvements) and needed to write the actual byte array to disk. 
